### PR TITLE
Change site language to es-PR

### DIFF
--- a/src/components/seo.tsx
+++ b/src/components/seo.tsx
@@ -71,7 +71,7 @@ export default function SEO({ description, lang, title, meta }: Props) {
 }
 
 SEO.defaultProps = {
-  lang: `es`,
+  lang: `es-PR`,
   meta: [],
   description: ``,
 }


### PR DESCRIPTION
Cambiando el lenguaje a `es-PR` ayuda a esfuerzos de catalogar el uso del idioma del español usado en Puerto Rico por entidades como [tesoro.pr](https://tesoro.pr).